### PR TITLE
Add newsletter module with posts, polls and gamification hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,33 @@ intranet_auvo/
 
 ---
 
+## 📰 Newsletter
+
+Rotas e página dedicadas ao painel de posts e enquetes em `/newsletter`.
+
+### Migração e Seed
+
+```bash
+flask db upgrade
+flask seed_newsletter
+```
+
+### Exemplos de payload
+
+Reação a post:
+
+```http
+POST /api/news/post/1/reacao
+{"tipo":"like"}
+```
+
+Voto em enquete:
+
+```http
+POST /api/news/enquete/1/voto
+{"opcoes":[1]}
+```
+
 ## 👨‍💻 Autor
 
 **Eduardo Lino** - [eduardoliino](mailto:eduardoliino)

--- a/app/newsletter/__init__.py
+++ b/app/newsletter/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+newsletter_bp = Blueprint('newsletter', __name__, template_folder='../templates', static_folder='../static')
+
+from . import routes  # noqa: E402

--- a/app/newsletter/models.py
+++ b/app/newsletter/models.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+from datetime import datetime
+from app import db
+
+
+class NewsPost(db.Model):
+    __tablename__ = 'tb_news_post'
+    id = db.Column(db.Integer, primary_key=True)
+    autor_id = db.Column(db.Integer, db.ForeignKey('colaborador.id'), nullable=False)
+    titulo = db.Column(db.String(200), nullable=False)
+    conteudo_md = db.Column(db.Text, nullable=True)
+    midias_json = db.Column(db.JSON, nullable=True)
+    publicado_em = db.Column(db.DateTime, default=datetime.utcnow)
+    atualizado_em = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    fixado_ordem = db.Column(db.Integer, nullable=True)
+    status = db.Column(db.Enum('rascunho', 'publicado', name='news_post_status'), default='publicado')
+
+    comentarios = db.relationship('NewsComentario', backref='post', lazy=True)
+    reacoes = db.relationship('NewsReacao', backref='post', lazy=True)
+    avaliacoes = db.relationship('NewsAvaliacao', backref='post', lazy=True)
+
+
+class NewsReacao(db.Model):
+    __tablename__ = 'tb_news_reacao'
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey('tb_news_post.id'), nullable=False)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('colaborador.id'), nullable=False)
+    tipo = db.Column(db.Enum('like', 'palmas', 'coracao', 'genial', 'feliz', name='news_reacao_tipo'), nullable=False)
+    criado_em = db.Column(db.DateTime, default=datetime.utcnow)
+    __table_args__ = (db.UniqueConstraint('post_id', 'usuario_id', name='uix_reacao_post_usuario'),)
+
+
+class NewsComentario(db.Model):
+    __tablename__ = 'tb_news_comentario'
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey('tb_news_post.id'), nullable=False)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('colaborador.id'), nullable=False)
+    texto = db.Column(db.Text, nullable=False)
+    gif_id = db.Column(db.String(64), nullable=True)
+    criado_em = db.Column(db.DateTime, default=datetime.utcnow)
+    editado_em = db.Column(db.DateTime, nullable=True)
+    excluido = db.Column(db.Boolean, default=False)
+
+
+class NewsAvaliacao(db.Model):
+    __tablename__ = 'tb_news_avaliacao'
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey('tb_news_post.id'), nullable=False)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('colaborador.id'), nullable=False)
+    estrelas = db.Column(db.Integer, nullable=False)
+    criado_em = db.Column(db.DateTime, default=datetime.utcnow)
+    __table_args__ = (db.UniqueConstraint('post_id', 'usuario_id', name='uix_avaliacao_post_usuario'),)
+
+
+class NewsEnquete(db.Model):
+    __tablename__ = 'tb_news_enquete'
+    id = db.Column(db.Integer, primary_key=True)
+    autor_id = db.Column(db.Integer, db.ForeignKey('colaborador.id'), nullable=False)
+    pergunta = db.Column(db.Text, nullable=False)
+    descricao = db.Column(db.Text, nullable=True)
+    tipo_selecao = db.Column(db.Enum('single', 'multi', name='news_enquete_tipo'), default='single')
+    anonima = db.Column(db.Boolean, default=True)
+    vis_resultado = db.Column(db.Enum('always', 'after_vote', 'after_close', name='news_enquete_vis'), default='after_vote')
+    inicio_em = db.Column(db.DateTime, nullable=True)
+    fim_em = db.Column(db.DateTime, nullable=True)
+    fixado_ordem = db.Column(db.Integer, nullable=True)
+    status = db.Column(db.Enum('rascunho', 'aberta', 'encerrada', name='news_enquete_status'), default='aberta')
+
+    opcoes = db.relationship('NewsEnqueteOpcao', backref='enquete', lazy=True)
+
+
+class NewsEnqueteOpcao(db.Model):
+    __tablename__ = 'tb_news_enquete_opcao'
+    id = db.Column(db.Integer, primary_key=True)
+    enquete_id = db.Column(db.Integer, db.ForeignKey('tb_news_enquete.id'), nullable=False)
+    texto = db.Column(db.String(255), nullable=False)
+    ordem = db.Column(db.Integer, nullable=False)
+
+
+class NewsEnqueteVoto(db.Model):
+    __tablename__ = 'tb_news_enquete_voto'
+    id = db.Column(db.Integer, primary_key=True)
+    enquete_id = db.Column(db.Integer, db.ForeignKey('tb_news_enquete.id'), nullable=False)
+    opcao_id = db.Column(db.Integer, db.ForeignKey('tb_news_enquete_opcao.id'), nullable=False)
+    usuario_id = db.Column(db.Integer, nullable=True)
+    hash_anon = db.Column(db.String(64), nullable=True)
+    criado_em = db.Column(db.DateTime, default=datetime.utcnow)
+    __table_args__ = (
+        db.UniqueConstraint('enquete_id', 'usuario_id', 'opcao_id', name='uix_voto_ident'),
+        db.UniqueConstraint('enquete_id', 'hash_anon', 'opcao_id', name='uix_voto_anon'),
+    )

--- a/app/newsletter/routes.py
+++ b/app/newsletter/routes.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+from datetime import datetime, timedelta
+import hashlib
+import json
+import re
+
+from flask import render_template, request, jsonify, abort
+from flask_login import login_required, current_user
+
+from app import db
+from app.utils.gamificacao_utils import registrar_acao
+
+from . import newsletter_bp
+from .models import (
+    NewsPost,
+    NewsReacao,
+    NewsComentario,
+    NewsAvaliacao,
+    NewsEnquete,
+    NewsEnqueteOpcao,
+    NewsEnqueteVoto,
+)
+
+
+# Helpers -------------------------------------------------
+
+def sanitize_comment(text: str) -> str:
+    if re.search(r"https?://", text):
+        raise ValueError("Links não são permitidos nos comentários")
+    return text
+
+
+def get_user_hash(enquete_id: int, usuario_id: int) -> str:
+    base = f"{enquete_id}:{usuario_id}:pepper".encode()
+    return hashlib.sha256(base).hexdigest()
+
+
+# Feed ----------------------------------------------------
+
+@newsletter_bp.route('/newsletter')
+@login_required
+def feed():
+    tipo = request.args.get('tipo', 'all')
+    search = request.args.get('search', '')
+    periodo = int(request.args.get('periodo', 30))
+    limite = datetime.utcnow() - timedelta(days=periodo)
+
+    posts_q = NewsPost.query.filter(NewsPost.publicado_em >= limite, NewsPost.status == 'publicado')
+    enquetes_q = NewsEnquete.query.filter(NewsEnquete.status != 'rascunho')
+
+    if search:
+        posts_q = posts_q.filter(NewsPost.titulo.ilike(f"%{search}%"))
+        enquetes_q = enquetes_q.filter(NewsEnquete.pergunta.ilike(f"%{search}%"))
+
+    fixados_posts = posts_q.filter(NewsPost.fixado_ordem.isnot(None)).order_by(NewsPost.fixado_ordem).all()
+    fixados_enquetes = enquetes_q.filter(NewsEnquete.fixado_ordem.isnot(None)).order_by(NewsEnquete.fixado_ordem).all()
+
+    feed_posts = []
+    if tipo in ('all', 'post'):
+        feed_posts.extend(posts_q.filter(NewsPost.fixado_ordem.is_(None)).order_by(NewsPost.publicado_em.desc()).all())
+    feed_enquetes = []
+    if tipo in ('all', 'enquete'):
+        feed_enquetes.extend(enquetes_q.filter(NewsEnquete.fixado_ordem.is_(None)).order_by(NewsEnquete.inicio_em.desc()).all())
+
+    return render_template(
+        'newsletter.html',
+        fixados_posts=fixados_posts,
+        fixados_enquetes=fixados_enquetes,
+        feed_posts=feed_posts,
+        feed_enquetes=feed_enquetes,
+    )
+
+
+# Post modais ---------------------------------------------
+
+@newsletter_bp.route('/newsletter/post/<int:post_id>')
+@login_required
+def ver_post(post_id: int):
+    post = NewsPost.query.get_or_404(post_id)
+    return render_template('newsletter_post_modal.html', post=post)
+
+
+@newsletter_bp.route('/newsletter/enquete/<int:enquete_id>')
+@login_required
+def ver_enquete(enquete_id: int):
+    enquete = NewsEnquete.query.get_or_404(enquete_id)
+    return render_template('newsletter_enquete_modal.html', enquete=enquete)
+
+
+# Reações -------------------------------------------------
+
+@newsletter_bp.post('/api/news/post/<int:post_id>/reacao')
+@login_required
+def reagir(post_id: int):
+    tipo = request.json.get('tipo')
+    if tipo not in {'like', 'palmas', 'coracao', 'genial', 'feliz'}:
+        abort(400)
+    reacao = NewsReacao.query.filter_by(post_id=post_id, usuario_id=current_user.id).first()
+    if reacao:
+        reacao.tipo = tipo
+    else:
+        reacao = NewsReacao(post_id=post_id, usuario_id=current_user.id, tipo=tipo)
+        db.session.add(reacao)
+    db.session.commit()
+    registrar_acao(current_user.id, "reagir_post", "post", post_id)
+    return jsonify({'status': 'ok'})
+
+
+@newsletter_bp.delete('/api/news/post/<int:post_id>/reacao')
+@login_required
+def remover_reacao(post_id: int):
+    reacao = NewsReacao.query.filter_by(post_id=post_id, usuario_id=current_user.id).first()
+    if reacao:
+        db.session.delete(reacao)
+        db.session.commit()
+        registrar_acao(current_user.id, "remover_reacao", "post", post_id)
+    return jsonify({'status': 'ok'})
+
+
+# Comentários --------------------------------------------
+
+@newsletter_bp.get('/api/news/post/<int:post_id>/comentarios')
+@login_required
+def listar_comentarios(post_id: int):
+    page = int(request.args.get('page', 1))
+    limit = int(request.args.get('limit', 20))
+    comentarios = NewsComentario.query.filter_by(post_id=post_id, excluido=False) \
+        .order_by(NewsComentario.criado_em).paginate(page=page, per_page=limit, error_out=False)
+    data = [
+        {
+            'id': c.id,
+            'usuario_id': c.usuario_id,
+            'texto': c.texto,
+            'gif_id': c.gif_id,
+            'criado_em': c.criado_em.isoformat(),
+        } for c in comentarios.items
+    ]
+    return jsonify({'comentarios': data, 'total': comentarios.total})
+
+
+@newsletter_bp.post('/api/news/post/<int:post_id>/comentarios')
+@login_required
+def criar_comentario(post_id: int):
+    texto = request.json.get('texto', '').strip()
+    gif_id = request.json.get('gif_id')
+    try:
+        texto = sanitize_comment(texto)
+    except ValueError as e:
+        abort(400, str(e))
+    comentario = NewsComentario(post_id=post_id, usuario_id=current_user.id, texto=texto, gif_id=gif_id)
+    db.session.add(comentario)
+    db.session.commit()
+    registrar_acao(current_user.id, "comentar_post", "post", post_id)
+    return jsonify({'id': comentario.id})
+
+
+@newsletter_bp.patch('/api/news/comentario/<int:comentario_id>')
+@login_required
+def editar_comentario(comentario_id: int):
+    comentario = NewsComentario.query.get_or_404(comentario_id)
+    if comentario.usuario_id != current_user.id and not current_user.is_admin:
+        abort(403)
+    texto = request.json.get('texto', '').strip()
+    try:
+        comentario.texto = sanitize_comment(texto)
+        comentario.editado_em = datetime.utcnow()
+        db.session.commit()
+        registrar_acao(current_user.id, "editar_comentario", "post", comentario_id)
+    except ValueError as e:
+        abort(400, str(e))
+    return jsonify({'status': 'ok'})
+
+
+@newsletter_bp.delete('/api/news/comentario/<int:comentario_id>')
+@login_required
+def excluir_comentario(comentario_id: int):
+    comentario = NewsComentario.query.get_or_404(comentario_id)
+    if comentario.usuario_id != current_user.id and not current_user.is_admin:
+        abort(403)
+    comentario.excluido = True
+    db.session.commit()
+    registrar_acao(current_user.id, "excluir_comentario", "post", comentario_id)
+    return jsonify({'status': 'ok'})
+
+
+# Avaliação ----------------------------------------------
+
+@newsletter_bp.put('/api/news/post/<int:post_id>/avaliacao')
+@login_required
+def avaliar_post(post_id: int):
+    estrelas = int(request.json.get('estrelas', 0))
+    if not 1 <= estrelas <= 5:
+        abort(400)
+    avaliacao = NewsAvaliacao.query.filter_by(post_id=post_id, usuario_id=current_user.id).first()
+    if avaliacao:
+        avaliacao.estrelas = estrelas
+    else:
+        avaliacao = NewsAvaliacao(post_id=post_id, usuario_id=current_user.id, estrelas=estrelas)
+        db.session.add(avaliacao)
+    db.session.commit()
+    registrar_acao(current_user.id, "avaliar_post", "post", post_id, {"estrelas": estrelas})
+    return jsonify({'status': 'ok'})
+
+
+# Enquetes ------------------------------------------------
+
+@newsletter_bp.post('/api/news/enquete/<int:enquete_id>/voto')
+@login_required
+def votar_enquete(enquete_id: int):
+    enquete = NewsEnquete.query.get_or_404(enquete_id)
+    if enquete.status != 'aberta':
+        abort(400, 'Enquete não está aberta')
+    opcoes = request.json.get('opcoes', [])
+    if enquete.tipo_selecao == 'single' and len(opcoes) != 1:
+        abort(400)
+    if enquete.tipo_selecao == 'multi' and len(opcoes) < 1:
+        abort(400)
+
+    usuario_id = current_user.id if not enquete.anonima else None
+    hash_anon = None
+    if enquete.anonima:
+        hash_anon = get_user_hash(enquete.id, current_user.id)
+
+    # remove votos anteriores
+    if enquete.anonima:
+        NewsEnqueteVoto.query.filter_by(enquete_id=enquete.id, hash_anon=hash_anon).delete()
+    else:
+        NewsEnqueteVoto.query.filter_by(enquete_id=enquete.id, usuario_id=current_user.id).delete()
+
+    for opcao_id in opcoes:
+        voto = NewsEnqueteVoto(
+            enquete_id=enquete.id,
+            opcao_id=opcao_id,
+            usuario_id=usuario_id,
+            hash_anon=hash_anon,
+        )
+        db.session.add(voto)
+    db.session.commit()
+    registrar_acao(current_user.id, "votar_enquete", "enquete", enquete_id, {"opcoes": opcoes})
+    return jsonify({'status': 'ok'})
+
+
+@newsletter_bp.get('/api/news/enquete/<int:enquete_id>/resultado')
+@login_required
+def resultado_enquete(enquete_id: int):
+    enquete = NewsEnquete.query.get_or_404(enquete_id)
+    pode_ver = False
+    if enquete.vis_resultado == 'always':
+        pode_ver = True
+    elif enquete.vis_resultado == 'after_vote':
+        if enquete.anonima:
+            hash_anon = get_user_hash(enquete.id, current_user.id)
+            voto = NewsEnqueteVoto.query.filter_by(enquete_id=enquete.id, hash_anon=hash_anon).first()
+        else:
+            voto = NewsEnqueteVoto.query.filter_by(enquete_id=enquete.id, usuario_id=current_user.id).first()
+        if voto:
+            pode_ver = True
+    elif enquete.vis_resultado == 'after_close' and enquete.status == 'encerrada':
+        pode_ver = True
+    if not pode_ver:
+        abort(403)
+    resultados = (
+        db.session.query(NewsEnqueteOpcao.id, NewsEnqueteOpcao.texto, db.func.count(NewsEnqueteVoto.id))
+        .outerjoin(NewsEnqueteVoto, NewsEnqueteVoto.opcao_id == NewsEnqueteOpcao.id)
+        .filter(NewsEnqueteOpcao.enquete_id == enquete.id)
+        .group_by(NewsEnqueteOpcao.id)
+        .order_by(NewsEnqueteOpcao.ordem)
+        .all()
+    )
+    data = [{'id': oid, 'texto': texto, 'votos': votos} for oid, texto, votos in resultados]
+    return jsonify({'opcoes': data})
+
+
+# Admin ---------------------------------------------------
+
+@newsletter_bp.route('/newsletter/admin')
+@login_required
+def admin_page():
+    if not current_user.is_admin:
+        abort(403)
+    posts = NewsPost.query.order_by(NewsPost.publicado_em.desc()).all()
+    enquetes = NewsEnquete.query.order_by(NewsEnquete.id.desc()).all()
+    return render_template('admin/gerenciar_newsletter.html', posts=posts, enquetes=enquetes)
+
+
+@newsletter_bp.post('/api/news/post')
+@login_required
+def criar_post():
+    if not current_user.is_admin:
+        abort(403)
+    data = request.json
+    post = NewsPost(
+        autor_id=current_user.id,
+        titulo=data.get('titulo'),
+        conteudo_md=data.get('conteudo_md'),
+        midias_json=data.get('midias_json'),
+        publicado_em=datetime.utcnow(),
+        status=data.get('status', 'publicado'),
+    )
+    db.session.add(post)
+    db.session.commit()
+    return jsonify({'id': post.id})
+
+
+@newsletter_bp.patch('/api/news/post/<int:post_id>')
+@login_required
+def editar_post(post_id: int):
+    if not current_user.is_admin:
+        abort(403)
+    post = NewsPost.query.get_or_404(post_id)
+    data = request.json
+    for campo in ['titulo', 'conteudo_md', 'midias_json', 'status']:
+        if campo in data:
+            setattr(post, campo, data[campo])
+    db.session.commit()
+    return jsonify({'status': 'ok'})
+
+
+@newsletter_bp.delete('/api/news/post/<int:post_id>')
+@login_required
+def excluir_post(post_id: int):
+    if not current_user.is_admin:
+        abort(403)
+    post = NewsPost.query.get_or_404(post_id)
+    db.session.delete(post)
+    db.session.commit()
+    return jsonify({'status': 'ok'})
+
+
+@newsletter_bp.post('/api/news/enquete')
+@login_required
+def criar_enquete():
+    if not current_user.is_admin:
+        abort(403)
+    data = request.json
+    enquete = NewsEnquete(
+        autor_id=current_user.id,
+        pergunta=data['pergunta'],
+        descricao=data.get('descricao'),
+        tipo_selecao=data.get('tipo_selecao', 'single'),
+        anonima=data.get('anonima', True),
+        vis_resultado=data.get('vis_resultado', 'after_vote'),
+        inicio_em=data.get('inicio_em'),
+        fim_em=data.get('fim_em'),
+    )
+    db.session.add(enquete)
+    db.session.flush()
+    opcoes = data.get('opcoes', [])
+    for idx, texto in enumerate(opcoes):
+        db.session.add(NewsEnqueteOpcao(enquete_id=enquete.id, texto=texto, ordem=idx))
+    db.session.commit()
+    return jsonify({'id': enquete.id})
+
+
+@newsletter_bp.patch('/api/news/enquete/<int:enquete_id>')
+@login_required
+def editar_enquete(enquete_id: int):
+    if not current_user.is_admin:
+        abort(403)
+    enquete = NewsEnquete.query.get_or_404(enquete_id)
+    data = request.json
+    for campo in ['pergunta', 'descricao', 'tipo_selecao', 'anonima', 'vis_resultado', 'inicio_em', 'fim_em', 'status']:
+        if campo in data:
+            setattr(enquete, campo, data[campo])
+    db.session.commit()
+    return jsonify({'status': 'ok'})
+
+
+@newsletter_bp.post('/api/news/enquete/<int:enquete_id>/encerrar')
+@login_required
+def encerrar_enquete(enquete_id: int):
+    if not current_user.is_admin:
+        abort(403)
+    enquete = NewsEnquete.query.get_or_404(enquete_id)
+    enquete.status = 'encerrada'
+    db.session.commit()
+    return jsonify({'status': 'ok'})
+
+
+@newsletter_bp.post('/api/news/fixar')
+@login_required
+def fixar():
+    if not current_user.is_admin:
+        abort(403)
+    tipo = request.json.get('tipo')
+    ref_id = request.json.get('ref_id')
+    ordem = request.json.get('ordem')
+    if tipo == 'post':
+        obj = NewsPost.query.get_or_404(ref_id)
+    else:
+        obj = NewsEnquete.query.get_or_404(ref_id)
+    obj.fixado_ordem = ordem
+    db.session.commit()
+    return jsonify({'status': 'ok'})
+
+
+@newsletter_bp.delete('/api/news/fixar/<string:tipo>/<int:ref_id>')
+@login_required
+def desfazer_fixacao(tipo: str, ref_id: int):
+    if not current_user.is_admin:
+        abort(403)
+    if tipo == 'post':
+        obj = NewsPost.query.get_or_404(ref_id)
+    else:
+        obj = NewsEnquete.query.get_or_404(ref_id)
+    obj.fixado_ordem = None
+    db.session.commit()
+    return jsonify({'status': 'ok'})

--- a/app/static/js/newsletter-api.js
+++ b/app/static/js/newsletter-api.js
@@ -1,0 +1,64 @@
+async function react(tipo, postId) {
+  await fetch(`/api/news/post/${postId}/reacao`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tipo })
+  });
+}
+
+async function unreact(postId) {
+  await fetch(`/api/news/post/${postId}/reacao`, { method: 'DELETE' });
+}
+
+async function listComments(postId, page=1, limit=20) {
+  const resp = await fetch(`/api/news/post/${postId}/comentarios?page=${page}&limit=${limit}`);
+  return resp.json();
+}
+
+async function createComment(postId, texto, gif_id=null) {
+  await fetch(`/api/news/post/${postId}/comentarios`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ texto, gif_id })
+  });
+}
+
+async function updateComment(id, texto) {
+  await fetch(`/api/news/comentario/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ texto })
+  });
+}
+
+async function deleteComment(id) {
+  await fetch(`/api/news/comentario/${id}`, { method: 'DELETE' });
+}
+
+async function ratePost(postId, estrelas) {
+  await fetch(`/api/news/post/${postId}/avaliacao`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ estrelas: parseInt(estrelas) })
+  });
+}
+
+async function votePoll(enqueteId) {
+  const container = document.getElementById(`enquete-opts-${enqueteId}`);
+  const inputs = container.querySelectorAll('input[name="opcao"]');
+  const opcoes = [];
+  inputs.forEach(i => { if (i.checked) opcoes.push(parseInt(i.value)); });
+  await fetch(`/api/news/enquete/${enqueteId}/voto`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ opcoes })
+  });
+  const r = await pollResults(enqueteId);
+  renderPollResults(enqueteId, r);
+}
+
+async function pollResults(enqueteId) {
+  const resp = await fetch(`/api/news/enquete/${enqueteId}/resultado`);
+  if (resp.status === 200) return resp.json();
+  return null;
+}

--- a/app/static/js/newsletter-ui.js
+++ b/app/static/js/newsletter-ui.js
@@ -1,0 +1,21 @@
+window.react = react;
+window.unreact = unreact;
+window.createComment = createComment;
+window.updateComment = updateComment;
+window.deleteComment = deleteComment;
+window.ratePost = ratePost;
+window.votePoll = votePoll;
+window.pollResults = pollResults;
+
+function renderPollResults(enqueteId, data){
+  if(!data) return;
+  const cont = document.getElementById(`resultado-${enqueteId}`);
+  if(!cont) return;
+  cont.innerHTML='';
+  data.opcoes.forEach(o=>{
+    const p=document.createElement('p');
+    p.textContent=`${o.texto} - ${o.votos} votos`;
+    cont.appendChild(p);
+  });
+}
+window.renderPollResults = renderPollResults;

--- a/app/templates/admin/gerenciar_newsletter.html
+++ b/app/templates/admin/gerenciar_newsletter.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container p-4">
+  <h1 class="mb-4">Admin Newsletter</h1>
+  <div class="mb-4">
+    <h2>Posts</h2>
+    <ul>
+    {% for p in posts %}
+      <li>{{ p.titulo }} ({{ p.status }})</li>
+    {% endfor %}
+    </ul>
+  </div>
+  <div>
+    <h2>Enquetes</h2>
+    <ul>
+    {% for e in enquetes %}
+      <li>{{ e.pergunta }} ({{ e.status }})</li>
+    {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -69,6 +69,7 @@
                     <a href="{{ url_for('main.ouvidoria') }}" class="list-group-item"><i class="bi bi-ear-fill"></i> Ouvidoria</a>
                     <a href="{{ url_for('main.faq_publico') }}" class="list-group-item"><i class="bi bi-patch-question-fill"></i> FAQ</a>
                     <a href="{{ url_for('main.ver_organograma') }}" class="list-group-item"><i class="bi bi-diagram-3-fill"></i> Organograma</a>
+                    <a href="{{ url_for('newsletter.feed') }}" class="list-group-item"><i class="bi bi-newspaper"></i> Newsletter</a>
                 </div>
 
                 {% if current_user.is_admin or current_user.permissoes %}
@@ -115,6 +116,7 @@
                     <a href="{{ url_for('main.ouvidoria') }}" class="list-group-item"><i class="bi bi-ear-fill"></i> Ouvidoria</a>
                     <a href="{{ url_for('main.faq_publico') }}" class="list-group-item"><i class="bi bi-patch-question-fill"></i> FAQ</a>
                     <a href="{{ url_for('main.ver_organograma') }}" class="list-group-item"><i class="bi bi-diagram-3-fill"></i> Organograma</a>
+                    <a href="{{ url_for('newsletter.feed') }}" class="list-group-item"><i class="bi bi-newspaper"></i> Newsletter</a>
                 </div>
                 {% if current_user.is_admin or current_user.permissoes %}
                     <hr class="mx-3" style="color: rgba(255,255,255,0.3);">

--- a/app/templates/newsletter.html
+++ b/app/templates/newsletter.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="max-w-3xl mx-auto p-4" x-data>
+  <h1 class="text-2xl font-bold mb-4">Newsletter</h1>
+  <div id="destaques" class="space-y-4 mb-6">
+    {% for post in fixados_posts %}
+      {% include 'partials/news_post_card.html' %}
+    {% endfor %}
+    {% for enquete in fixados_enquetes %}
+      {% include 'partials/news_enquete_card.html' %}
+    {% endfor %}
+  </div>
+  <div id="feed" class="space-y-4">
+    {% for post in feed_posts %}
+      {% include 'partials/news_post_card.html' %}
+    {% endfor %}
+    {% for enquete in feed_enquetes %}
+      {% include 'partials/news_enquete_card.html' %}
+    {% endfor %}
+  </div>
+</div>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="{{ url_for('static', filename='js/newsletter-api.js') }}"></script>
+<script src="{{ url_for('static', filename='js/newsletter-ui.js') }}"></script>
+{% endblock %}

--- a/app/templates/newsletter_enquete_modal.html
+++ b/app/templates/newsletter_enquete_modal.html
@@ -1,0 +1,12 @@
+<div x-data>
+  <h2 class="text-xl font-bold mb-2">{{ enquete.pergunta }}</h2>
+  <div class="space-y-1" id="enquete-opts-{{enquete.id}}">
+    {% for opcao in enquete.opcoes|sort(attribute='ordem') %}
+    <label class="block">
+      <input type="{{ 'checkbox' if enquete.tipo_selecao=='multi' else 'radio' }}" name="opcao" value="{{ opcao.id }}" class="mr-2">{{ opcao.texto }}
+    </label>
+    {% endfor %}
+  </div>
+  <button class="bg-blue-500 text-white px-2 mt-2" @click="votePoll({{enquete.id}})">Votar</button>
+  <div id="resultado-{{enquete.id}}" class="mt-4"></div>
+</div>

--- a/app/templates/newsletter_post_modal.html
+++ b/app/templates/newsletter_post_modal.html
@@ -1,0 +1,26 @@
+<div class="space-y-2" x-data="{novoComentario:'', estrelas:''}">
+  <h2 class="text-xl font-bold">{{ post.titulo }}</h2>
+  <div class="prose max-w-none">{{ post.conteudo_md }}</div>
+  <div class="flex space-x-2 mt-2">
+    {% for r in ['like','palmas','coracao','genial','feliz'] %}
+    <button class="px-2" @click.stop="react('{{r}}', {{post.id}})">{{ {'like':'👍','palmas':'👏','coracao':'❤️','genial':'💡','feliz':'😊'}[r] }}</button>
+    {% endfor %}
+  </div>
+  <div id="comentarios-{{post.id}}" class="space-y-1 mt-2">
+    {% for c in post.comentarios %}
+      {% if not c.excluido %}
+      <p class="text-sm">{{ c.texto }}</p>
+      {% endif %}
+    {% endfor %}
+  </div>
+  <div class="mt-2 flex space-x-2">
+    <input type="text" class="border flex-1" x-model="novoComentario" placeholder="Comentário" />
+    <button class="bg-blue-500 text-white px-2" @click="createComment({{post.id}}, novoComentario); novoComentario=''">Enviar</button>
+  </div>
+  <div class="mt-2">
+    <select x-model="estrelas" @change="ratePost({{post.id}}, estrelas)">
+      <option value="">Avaliar</option>
+      {% for i in range(1,6) %}<option value="{{i}}">{{i}} ⭐</option>{% endfor %}
+    </select>
+  </div>
+</div>

--- a/app/templates/partials/news_enquete_card.html
+++ b/app/templates/partials/news_enquete_card.html
@@ -1,0 +1,12 @@
+<div class="border rounded p-4 shadow-sm" x-data="{open:false}" @click="open=true">
+  <h2 class="font-semibold">{{ enquete.pergunta }}</h2>
+  <p class="text-xs text-gray-500">{{ 'Encerrada' if enquete.status == 'encerrada' else 'Aberta' }}</p>
+  <div x-show="open" x-cloak>
+    <div class="fixed inset-0 bg-black/50" @click="open=false"></div>
+    <div class="fixed inset-0 flex items-center justify-center">
+      <div class="bg-white p-4 rounded shadow max-w-xl w-full overflow-y-auto max-h-full">
+        {% include 'newsletter_enquete_modal.html' %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/templates/partials/news_post_card.html
+++ b/app/templates/partials/news_post_card.html
@@ -1,0 +1,23 @@
+<div class="border rounded p-4 shadow-sm" x-data="{open:false}" @click="open=true">
+  <h2 class="font-semibold">{{ post.titulo }}</h2>
+  <p class="text-sm text-gray-700 line-clamp-3">{{ post.conteudo_md[:150] }}</p>
+  <div class="text-xs text-gray-500 mt-2">
+    <span>{{ post.reacoes|length }} reações</span>
+    <span class="ml-2">{{ post.comentarios|selectattr('excluido','equalto',False)|list|length }} comentários</span>
+  </div>
+  <div class="mt-2 space-y-1">
+    {% for c in post.comentarios[:3] %}
+      {% if not c.excluido %}
+      <p class="text-sm">{{ c.texto }}</p>
+      {% endif %}
+    {% endfor %}
+  </div>
+  <div x-show="open" x-cloak>
+    <div class="fixed inset-0 bg-black/50" @click="open=false"></div>
+    <div class="fixed inset-0 flex items-center justify-center">
+      <div class="bg-white p-4 rounded shadow max-w-xl w-full overflow-y-auto max-h-full">
+        {% include 'newsletter_post_modal.html' %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/utils/gamificacao_utils.py
+++ b/app/utils/gamificacao_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from typing import Optional, Dict
+
+from app import db
+from datetime import datetime
+
+
+class GamLog(db.Model):
+    __tablename__ = 'tb_gam_log'
+    id = db.Column(db.Integer, primary_key=True)
+    usuario_id = db.Column(db.Integer, nullable=False)
+    acao = db.Column(db.String(50), nullable=False)
+    ref_tipo = db.Column(db.String(20), nullable=False)
+    ref_id = db.Column(db.Integer, nullable=False)
+    meta_json = db.Column(db.JSON, nullable=True)
+    criado_em = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+def registrar_acao(usuario_id: int, acao: str, ref_tipo: str, ref_id: int, meta: Optional[Dict] = None) -> None:
+    """Gancho de gamificação. Fase 1 grava apenas log de ações."""
+    log = GamLog(usuario_id=usuario_id, acao=acao, ref_tipo=ref_tipo, ref_id=ref_id, meta_json=meta)
+    db.session.add(log)
+    db.session.commit()
+    return

--- a/migrations/versions/a1b2c3d4e5f6_add_newsletter_tables.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_newsletter_tables.py
@@ -1,0 +1,107 @@
+"""add newsletter tables
+
+Revision ID: a1b2c3d4e5f6
+Revises: e0061a47d8c5
+Create Date: 2024-01-01 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'a1b2c3d4e5f6'
+down_revision = 'e0061a47d8c5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('tb_news_post',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('autor_id', sa.Integer, sa.ForeignKey('colaborador.id'), nullable=False),
+        sa.Column('titulo', sa.String(200), nullable=False),
+        sa.Column('conteudo_md', sa.Text),
+        sa.Column('midias_json', sa.JSON),
+        sa.Column('publicado_em', sa.DateTime, nullable=False),
+        sa.Column('atualizado_em', sa.DateTime, nullable=False),
+        sa.Column('fixado_ordem', sa.Integer),
+        sa.Column('status', sa.Enum('rascunho','publicado', name='news_post_status'), nullable=False, server_default='publicado')
+    )
+    op.create_table('tb_news_reacao',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('post_id', sa.Integer, sa.ForeignKey('tb_news_post.id'), nullable=False),
+        sa.Column('usuario_id', sa.Integer, sa.ForeignKey('colaborador.id'), nullable=False),
+        sa.Column('tipo', sa.Enum('like','palmas','coracao','genial','feliz', name='news_reacao_tipo'), nullable=False),
+        sa.Column('criado_em', sa.DateTime, nullable=False),
+        sa.UniqueConstraint('post_id','usuario_id', name='uix_reacao_post_usuario')
+    )
+    op.create_table('tb_news_comentario',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('post_id', sa.Integer, sa.ForeignKey('tb_news_post.id'), nullable=False),
+        sa.Column('usuario_id', sa.Integer, sa.ForeignKey('colaborador.id'), nullable=False),
+        sa.Column('texto', sa.Text, nullable=False),
+        sa.Column('gif_id', sa.String(64)),
+        sa.Column('criado_em', sa.DateTime, nullable=False),
+        sa.Column('editado_em', sa.DateTime),
+        sa.Column('excluido', sa.Boolean, nullable=False, server_default='0')
+    )
+    op.create_table('tb_news_avaliacao',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('post_id', sa.Integer, sa.ForeignKey('tb_news_post.id'), nullable=False),
+        sa.Column('usuario_id', sa.Integer, sa.ForeignKey('colaborador.id'), nullable=False),
+        sa.Column('estrelas', sa.Integer, nullable=False),
+        sa.Column('criado_em', sa.DateTime, nullable=False),
+        sa.UniqueConstraint('post_id','usuario_id', name='uix_avaliacao_post_usuario')
+    )
+    op.create_table('tb_news_enquete',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('autor_id', sa.Integer, sa.ForeignKey('colaborador.id'), nullable=False),
+        sa.Column('pergunta', sa.Text, nullable=False),
+        sa.Column('descricao', sa.Text),
+        sa.Column('tipo_selecao', sa.Enum('single','multi', name='news_enquete_tipo'), server_default='single'),
+        sa.Column('anonima', sa.Boolean, nullable=False, server_default='1'),
+        sa.Column('vis_resultado', sa.Enum('always','after_vote','after_close', name='news_enquete_vis'), server_default='after_vote'),
+        sa.Column('inicio_em', sa.DateTime),
+        sa.Column('fim_em', sa.DateTime),
+        sa.Column('fixado_ordem', sa.Integer),
+        sa.Column('status', sa.Enum('rascunho','aberta','encerrada', name='news_enquete_status'), server_default='aberta')
+    )
+    op.create_table('tb_news_enquete_opcao',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('enquete_id', sa.Integer, sa.ForeignKey('tb_news_enquete.id'), nullable=False),
+        sa.Column('texto', sa.String(255), nullable=False),
+        sa.Column('ordem', sa.Integer, nullable=False)
+    )
+    op.create_table('tb_news_enquete_voto',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('enquete_id', sa.Integer, sa.ForeignKey('tb_news_enquete.id'), nullable=False),
+        sa.Column('opcao_id', sa.Integer, sa.ForeignKey('tb_news_enquete_opcao.id'), nullable=False),
+        sa.Column('usuario_id', sa.Integer),
+        sa.Column('hash_anon', sa.String(64)),
+        sa.Column('criado_em', sa.DateTime, nullable=False),
+        sa.UniqueConstraint('enquete_id','usuario_id','opcao_id', name='uix_voto_ident'),
+        sa.UniqueConstraint('enquete_id','hash_anon','opcao_id', name='uix_voto_anon')
+    )
+    op.create_table('tb_gam_log',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('usuario_id', sa.Integer, nullable=False),
+        sa.Column('acao', sa.String(50), nullable=False),
+        sa.Column('ref_tipo', sa.String(20), nullable=False),
+        sa.Column('ref_id', sa.Integer, nullable=False),
+        sa.Column('meta_json', sa.JSON),
+        sa.Column('criado_em', sa.DateTime, nullable=False)
+    )
+
+
+def downgrade():
+    op.drop_table('tb_gam_log')
+    op.drop_table('tb_news_enquete_voto')
+    op.drop_table('tb_news_enquete_opcao')
+    op.drop_table('tb_news_enquete')
+    op.drop_table('tb_news_avaliacao')
+    op.drop_table('tb_news_comentario')
+    op.drop_table('tb_news_reacao')
+    op.drop_table('tb_news_post')
+    sa.Enum(name='news_post_status').drop(op.get_bind(), checkfirst=False)
+    sa.Enum(name='news_reacao_tipo').drop(op.get_bind(), checkfirst=False)
+    sa.Enum(name='news_enquete_tipo').drop(op.get_bind(), checkfirst=False)
+    sa.Enum(name='news_enquete_vis').drop(op.get_bind(), checkfirst=False)
+    sa.Enum(name='news_enquete_status').drop(op.get_bind(), checkfirst=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@ Flask
 Flask-SQLAlchemy
 Flask-Migrate
 Flask-Login
+Flask-Session
 pandas
 openpyxl
 Werkzeug
 python-dotenv
-Flask-Session
+bleach


### PR DESCRIPTION
## Summary
- create newsletter blueprint with feed, reactions, comments, ratings and polls
- add gamification logging hook and database tables
- expose new /newsletter UI and admin management

## Testing
- `python -m py_compile app/utils/gamificacao_utils.py app/newsletter/models.py app/newsletter/routes.py app/newsletter/__init__.py app/__init__.py`
- `flask db upgrade`


------
https://chatgpt.com/codex/tasks/task_e_68adaf0640648325a1684767ae39ae95